### PR TITLE
AppKit issetugid hack

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ Also see [here](https://github.com/moraea/non-metal-frameworks/projects/1) and [
 
 - investigate double menu bar clock with `Show date: when space allows` (workaround: set `always` or `never`)
 - investigate frozen indeterminate `NSProgressIndicator`s in wxWidgets apps?
-- prevent `Cycle Through Windows` reimplementation breaking Big Sur `sudo` and Monterey VirtualBox
 - fix stuttering/out-of-order frames when seeking in videos with Mojave QuartzCore
 - fix beachball with hardware cursor (workaround: downgrade `IOHIDFamily` to Catalina and edit WindowServer's sandbox file to allow `HIDWaitCursorFrameInterval`, or use [this](https://github.com/ASentientBot/monterey/releases/download/2022-3-20/you.can.edit.the.defines.to.make.it.spin.extremely.fast.or.even.backward.lol.zip) beta SkyLight plugin)
 - rewrite blur fix to work with Mojave QC and fix flickering/performance issues

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Also see [here](https://github.com/moraea/non-metal-frameworks/projects/1) and [
 - investigate double menu bar clock with `Show date: when space allows` (workaround: set `always` or `never`)
 - investigate frozen indeterminate `NSProgressIndicator`s in wxWidgets apps?
 - fix stuttering/out-of-order frames when seeking in videos with Mojave QuartzCore
-- fix blank Wabbitemu windows with Mojave QuartzCore
+- fix blank Wabbitemu, Anka VM windows with Mojave QuartzCore
 - fix beachball with hardware cursor (workaround: downgrade `IOHIDFamily` to Catalina and edit WindowServer's sandbox file to allow `HIDWaitCursorFrameInterval`, or use [this](https://github.com/ASentientBot/monterey/releases/download/2022-3-20/you.can.edit.the.defines.to.make.it.spin.extremely.fast.or.even.backward.lol.zip) beta SkyLight plugin)
 - rewrite blur fix to work with Mojave QC and fix flickering/performance issues
 - fix unresponsive password dialogs with downgraded QuartzCore

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Also see [here](https://github.com/moraea/non-metal-frameworks/projects/1) and [
 - investigate double menu bar clock with `Show date: when space allows` (workaround: set `always` or `never`)
 - investigate frozen indeterminate `NSProgressIndicator`s in wxWidgets apps?
 - fix stuttering/out-of-order frames when seeking in videos with Mojave QuartzCore
+- fix blank Wabbitemu windows with Mojave QuartzCore
 - fix beachball with hardware cursor (workaround: downgrade `IOHIDFamily` to Catalina and edit WindowServer's sandbox file to allow `HIDWaitCursorFrameInterval`, or use [this](https://github.com/ASentientBot/monterey/releases/download/2022-3-20/you.can.edit.the.defines.to.make.it.spin.extremely.fast.or.even.backward.lol.zip) beta SkyLight plugin)
 - rewrite blur fix to work with Mojave QC and fix flickering/performance issues
 - fix unresponsive password dialogs with downgraded QuartzCore

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Most users will want to just use [OCLP](https://dortania.github.io/OpenCore-Lega
 	- OpenCL downgrade
 	- Night Shift prefpane fix code
 	- Shim to selectively reenable transparency with reduce transparency enabled (ex. `defaults write com.apple.dock Moraea_EnableTransparency 1`)
+	- AppKit `issetugid` workaround help
 	- countless other code contributions, insights, and testing
 - [ASentientBot](https://asentientbot.github.io)
     - most fixes for Catalina/Big Sur (empty windows, empty menu bar, menu bar styling, sidebar glyphs, user input, sessions, display sleep, accessibility zoom, occlusion detection, several app and WindowServer crashes)
@@ -71,6 +72,9 @@ Most users will want to just use [OCLP](https://dortania.github.io/OpenCore-Lega
 Thank you as well to other contributors, moderators, and testers on [Unsupported Macs Discord](https://discord.gg/XbbWAsE), [OCLP Discord](https://discord.gg/rqdPgH8xSN), and [MacRumors Forums](https://forums.macrumors.com). Please contact us or open an issue if we forgot to mention you!
 
 ## changes
+
+### 2022-5-27
+- workaround VirtualBox AppKit `issetugid` crash with Cycle Through Windows implementation
 
 ### 2022-5-23
 - fix Discord (app) screen sharing by making it think it's on High Sierra

--- a/SkyLight/Main.m
+++ b/SkyLight/Main.m
@@ -76,8 +76,7 @@ BOOL isWindowServer;
 #if MAJOR==11
 	photosSetup();
 #else
-	// TODO: breaks VirtualBox currently, should fix ASAP...
-	// cycleSetup();
+	cycleSetup();
 #endif
 }
 


### PR DESCRIPTION
fix for VirtualBox and probably other things that break with Cycle Through Windows hack, and should prevent this issue with loading AppKit in privileged processes in the future.