### PR TITLE
add SL\*Preflight\*Access stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Most users will want to just use [OCLP](https://dortania.github.io/OpenCore-Lega
 	- countless other macOS insights, explanations, and help
 - [ASentientBot](https://asentientbot.github.io)
 	- most build scripts and stubbing/binpatching/swizzling utils
-    - misc fixes (defenestrator-on window contents, menu bar contents and styling, sidebar glyphs, user input, sessions, Dock collisions, display sleep, accessibility zoom, greyscale, occlusion detection, CABL/CAPL hacks, Cycle Through Windows, wait cursor, unresponsive Catalyst/SwiftUI buttons, sshd/cryptexd problem, various crashes)
+    - misc fixes (defenestrator-on window contents, menu bar contents and styling, sidebar glyphs, user input, sessions, Dock collisions, display sleep, accessibility zoom, greyscale, occlusion detection, CABL/CAPL hacks, Cycle Through Windows, wait cursor, unresponsive Catalyst/SwiftUI buttons, sshd/cryptexd, permissions, various crashes)
 	- downgraded QuartzCore fixes (animations, Catalyst issues, Siri issues, black videos)
 	- app-specific hacks (Photos, Discord, Safari, Books, Logic)
 	- Ventura SkyLight transactions/softlinks shims (many based on EduCovas's research, see above)
@@ -90,6 +90,7 @@ Thank you as well to other contributors, moderators, and testers on [Unsupported
 
 ### 2023-5-12
 - workaround `cryptexd`/`sshd` crashes due to SkyLight initializers
+- stub `SL*Preflight*Access()` functions (fix screen recording regression)
 
 ### 2023-3-27
 - implement automatic light/dark menubar text based on average wallpaper brightness, rounded selections, and text shadows (`defaults write -g Amy.MenuBar2Beta -bool true` to enable, will be on by default after further testing)

--- a/SkyLight/Main.m
+++ b/SkyLight/Main.m
@@ -43,6 +43,7 @@ BOOL isWindowServer;
 #import "Plugins.m"
 #import "Spin.m"
 #import "Done.m"
+#import "Preflight.m"
 
 #if MAJOR==11
 #import "Photos.m"

--- a/SkyLight/Preflight.m
+++ b/SkyLight/Preflight.m
@@ -1,0 +1,51 @@
+// old SkyLight doesn't need these checks, so just tell apps to go ahead
+
+BOOL SLPreflightListenEventAccess()
+{
+	return true;
+}
+BOOL SLPreflightPostEventAccess()
+{
+	return true;
+}
+BOOL SLPreflightScreenCaptureAccess()
+{
+	return true;
+}
+BOOL SLRequestListenEventAccess()
+{
+	return true;
+}
+BOOL SLRequestPostEventAccess()
+{
+	return true;
+}
+BOOL SLRequestScreenCaptureAccess()
+{
+	return true;
+}
+
+BOOL SLSPreflightListenEventAccess()
+{
+	return true;
+}
+BOOL SLSPreflightPostEventAccess()
+{
+	return true;
+}
+BOOL SLSPreflightScreenCaptureAccess()
+{
+	return true;
+}
+BOOL SLSRequestListenEventAccess()
+{
+	return true;
+}
+BOOL SLSRequestPostEventAccess()
+{
+	return true;
+}
+BOOL SLSRequestScreenCaptureAccess()
+{
+	return true;
+}


### PR DESCRIPTION
correctly tells apps that they have screen recording etc. access (10.14 SL doesn't need to ask permission for these; they always worked, but a few _thought_ they didn't work because of these functions). fixes a regression in either 11 or 12 shims (was fixed in ancient Cat codebase)