### PR TITLE
replace dock rects implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Thank you as well to other contributors, moderators, and testers on [Unsupported
 
 ## changes
 
+### 2023-5-29
+- replace `SLS*DockRectWithOrientation` implementation (fix incorrect orientation returned to root processes)
+
 ### 2023-5-12
 - workaround `cryptexd`/`sshd` crashes due to SkyLight initializers
 - stub `SL*Preflight*Access()` functions (fix screen recording regression)

--- a/SkyLight/Dock.m
+++ b/SkyLight/Dock.m
@@ -1,14 +1,28 @@
 // Dock collisions
 
+// new approach (2023-5-29): store orientation in "reason" rather than using HIServices
+// workaround CoreDock function not working as root
+
 void SLSGetDockRectWithOrientation(unsigned int edi_connectionID,CGRect* rsi_rectOut,char* rdx_reasonOut,unsigned long* rcx_orientationOut)
 {
-	SLSGetDockRectWithReason(edi_connectionID,rsi_rectOut,rdx_reasonOut);
+	int merged=0;
 	
-	unsigned long pinningIgnored;
-	CoreDockGetOrientationAndPinning(rcx_orientationOut,&pinningIgnored);
+	SLSGetDockRectWithReason(edi_connectionID,rsi_rectOut,&merged);
+	
+	*rdx_reasonOut=merged&0xffff;
+	*rcx_orientationOut=merged>>16;
+	
+	// SLSGetDockRectWithReason(edi_connectionID,rsi_rectOut,rdx_reasonOut);
+	
+	// unsigned long pinningIgnored;
+	// CoreDockGetOrientationAndPinning(rcx_orientationOut,&pinningIgnored);
 }
 
 void SLSSetDockRectWithOrientation(unsigned int edi_connectionID,unsigned int esi,unsigned int edx,CGRect stack_rect)
 {
-	SLSSetDockRectWithReason(edi_connectionID,esi,stack_rect);
+	int merged=esi|(edx<<16);
+	
+	SLSSetDockRectWithReason(edi_connectionID,merged,stack_rect);
+	
+	// SLSSetDockRectWithReason(edi_connectionID,esi,stack_rect);
 }


### PR DESCRIPTION
store orientation by packing into a member available in 10.14 SL rather than relying on HIServices which doesn't work in root processes launched with osascript